### PR TITLE
Upgraded supported angular to ~1.3.5

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,9 +16,9 @@
         "README.md"
     ],
     "dependencies": {
-      "angular": "~1.2.15"
+      "angular": "~1.3.5"
     },
     "devDependencies": {
-      "angular-mocks": "~1.2.15"
+      "angular-mocks": "~1.3.5"
     }
 }


### PR DESCRIPTION
jasmine-promise-matchers is compatable with at _least_ angular 1.3.5 when used with jasmine 2.0, and so it would be nice if it supported the latest version.

Instead of bumping support just to 1.3, we could support ~1.2 || ~1.3 if you like.
