### PR TITLE
resolve #24 add implicit flush for $timeout and $httpBackend

### DIFF
--- a/source/source.js
+++ b/source/source.js
@@ -1,11 +1,15 @@
 var installPromiseMatchers;
 
 (function() {
-  var $scope;
+  var $scope,
+      $httpBackend,
+      $timeout;
 
   installPromiseMatchers = function() {
     angular.mock.inject(function($injector) {
       $scope = $injector.get('$rootScope');
+      $httpBackend = $injector.get('$httpBackend');
+      $timeout = $injector.get('$timeout');
     });
   };
 
@@ -41,6 +45,24 @@ var installPromiseMatchers;
       });
 
     $scope.$apply(); // Trigger Promise resolution
+
+    // Trigger $httpBackend flush if any requests are pending
+    try {
+      $httpBackend.flush();
+    } catch (err) {
+      if (err.message !== 'No pending request to flush !') {
+        throw err;
+      }
+    }
+
+    // Trigger $timeout flush if any deferred tasks are pending
+    try {
+      $timeout.flush();
+    } catch (err) {
+      if (err.message !== 'No deferred tasks to be flushed') {
+        throw err;
+      }
+    }
 
     info.message = 'Expected ' + info.actualState + ' to be ' + expectedState;
     info.pass = info.actualState === expectedState;

--- a/tests/test.js
+++ b/tests/test.js
@@ -4,15 +4,24 @@
 angular.module('foobar', []);
 
 describe('Promise Matcher tests', function () {
-  var deferred;
+  var deferred,
+      $http,
+      $httpBackend,
+      $timeout;
 
   beforeEach(function() {
     angular.mock.module('foobar');
 
     installPromiseMatchers();
 
-    inject(function($q) {
+    inject(function($q,
+                    _$http_,
+                    _$httpBackend_,
+                    _$timeout_) {
       deferred = $q.defer();
+      $http = _$http_;
+      $httpBackend = _$httpBackend_;
+      $timeout = _$timeout_;
     });
   });
 
@@ -122,5 +131,18 @@ describe('Promise Matcher tests', function () {
     deferred.resolve(objectA);
 
     expect(deferred.promise).toBeResolvedWith(objectB);
+  });
+
+  it('should flush pending $timeouts', function() {
+    $timeout(function() {
+      deferred.resolve();
+    }, 1000);
+
+    expect(deferred.promise).toBeResolved();
+  });
+
+  it('should flush pending $http requests', function() {
+    $httpBackend.expectGET('/test').respond(200);
+    expect($http.get('/test')).toBeResolved();
   });
 });


### PR DESCRIPTION
This adds an implicit .flush() call for $httpBackend and $timeout after triggering the digest cycle. If the .flush() is not needed, the error that is thrown as a result is suppressed. Any other errors generated by triggering the .flush() are rethrown. 