### PR TITLE
Add `main` to `package.json` so `require` works

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "jasmine-promise-matchers",
+  "main": "dist/jasmine-promise-matchers.js",
   "version": "2.4.0",
   "homepage": "https://github.com/bvaughn/jasmine-promise-matchers",
   "repository": {


### PR DESCRIPTION
Without a `main` entry, `require('jasmine-promise-matchers')` and `require.resolve('jasmine-promise-matchers')` will fail.